### PR TITLE
Enable PDF Build

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -57,12 +57,11 @@
       "Pdf"
     ]
   },
-  "need_generate_pdf_url_template": false,
+  "need_generate_pdf_url_template": true,
   "need_generate_intellisense": false,
   "Targets": {
     "Pdf": {
       "template_folder": "_themes.pdf"
     }
-  },
-  "need_generate_pdf": false
+  }
 }


### PR DESCRIPTION
# Publiczne współtworzenie nie jest aktualnie akceptowane

To repozytorium zostało ustawione jako publiczne na potrzeby pobierania zawartości i używania jej do tworzenia dostosowanych rozwiązań Pomocy.
Aktualnie nie akceptujemy publicznego współtworzenia tego repozytorium lub tej zawartości.
Jeśli chcesz współtworzyć zawartość publikowaną przez firmę Microsoft, przejdź do repozytorium w angielskiej wersji językowej, gdzie możliwe jest publiczne współtworzenie.
